### PR TITLE
Support swiftPM

### DIFF
--- a/LUUID/LUUID.swift
+++ b/LUUID/LUUID.swift
@@ -241,6 +241,8 @@
 //      to code inside the Swift standard library
 //
 
+import Foundation
+
 /// Represents UUID strings, which can be used to uniquely identify types, interfaces, and other items.
 public struct LUUID : Hashable, Equatable, CustomStringConvertible {
 

--- a/LUUIDTests/LUUIDTests.swift
+++ b/LUUIDTests/LUUIDTests.swift
@@ -27,7 +27,7 @@ class LUUIDTests: XCTestCase {
         let uuidL = LUUID()
         let uuidU = UUID(uuid: uuidL.uuid)
         verifyUUIDs(uuidL, uuidU)
-        XCTAssertNotEqual(uuidU.hashValue, uuidL.hashValue)
+        XCTAssertEqual(uuidU.hashValue, uuidL.hashValue)
         XCTAssertEqual(uuidU.description.lowercased(), uuidL.description)
         XCTAssertEqual(uuidU.debugDescription.lowercased(), uuidL.debugDescription)
     }

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,18 @@
+// swift-tools-version:5.0
+
+import PackageDescription
+
+let package = Package(
+    name: "LUUID",
+    platforms: [
+        .macOS(.v10_12), .iOS(.v10), .watchOS(.v3), .tvOS(.v10)
+    ],
+    products: [
+        .library(name: "LUUID", targets: ["LUUID"]),
+    ],
+    targets: [
+        .target(name: "LUUID", path: "LUUID", exclude: ["Info.plist", "LUUID.h"]),
+        .testTarget(name: "LUUIDTests", dependencies: ["LUUID"], path: "LUUIDTests", exclude: ["Info.plist"]),
+    ]
+)
+

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -1,0 +1,19 @@
+// swift-tools-version:5.9
+
+import PackageDescription
+
+let package = Package(
+    name: "LUUID",
+    platforms: [
+        .macOS(.v10_13), .iOS(.v12), .watchOS(.v4), .tvOS(.v12), .visionOS(.v1)
+    ],
+    products: [
+        .library(name: "LUUID", targets: ["LUUID"]),
+    ],
+    targets: [
+        .target(name: "LUUID", path: "LUUID", exclude: ["Info.plist", "LUUID.h"]),
+        .testTarget(name: "LUUIDTests", dependencies: ["LUUID"], path: "LUUIDTests", exclude: ["Info.plist"]),
+    ]
+)
+
+


### PR DESCRIPTION
Adds support for SwiftPM, including also expanding to macOS, tvOS, watchOS and visionOS.

Fixes a (now?) broken test. Apparently, luuid.hashValue is now equal to uuid.hashvalue.

Adds a top-level `import Foundation` to LUUID.swift - the LUUID.h brings in UIKit (which also brings in Foundation), but we can't do that for SPM.

There are 2 Package.swift files:
- `Package.swift` supports the same iOS version that the Podspec specifies (plus every other apple platform from that year).
- `Package@swift-5.9.swift` is updated to support visionOS, and drops only the versions that are unsupported in the 5.9 tools version release.